### PR TITLE
BLD: explicitly require wheel as a buildtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,8 @@ requires = [
     "setuptools>=61.2",
     "Cython>=0.29.22,<3.0",
     "oldest-supported-numpy",
+    # see https://github.com/numpy/numpy/pull/18389
+    "wheel>=0.36.2",
 ]
 
 [project]


### PR DESCRIPTION
This prevents warnings from pip:
```
Run python -m pip install --editable "."
Obtaining file:///home/runner/work/ewah_bool_utils/ewah_bool_utils
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  WARNING: Missing build requirements in pyproject.toml for file:///home/runner/work/ewah_bool_utils/ewah_bool_utils.
  WARNING: The project does not specify a build backend, and pip cannot fall back to setuptools without 'wheel'.
```