### PR TITLE
ENH: add a get_include() function to facilitate downstream integration

### DIFF
--- a/ewah_bool_utils/__init__.py
+++ b/ewah_bool_utils/__init__.py
@@ -2,3 +2,12 @@
 
 
 from .ewah_bool_wrap import *
+
+
+def get_include():
+    """
+    Returns the directory that contains ewah*.h headers
+    """
+    import os
+
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "cpp"))


### PR DESCRIPTION
This resolves #17