### PR TITLE
MNT: cleanup redundant Cython instruction

### DIFF
--- a/ewah_bool_utils/_testing.pyx
+++ b/ewah_bool_utils/_testing.pyx
@@ -1,4 +1,3 @@
-#cython: language_level=3
 # Cython interface for ewah_bool_utils tests
 
 cimport cython


### PR DESCRIPTION
language_level is already set in `setup.py`