### PR TITLE
BLD: add wheels for CPython 3.12

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -25,11 +25,11 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Build wheels for CPython
-      uses: pypa/cibuildwheel@v2.14.1
+      uses: pypa/cibuildwheel@v2.15.0
       with:
         output-dir: dist
       env:
-        CIBW_BUILD: cp38-* cp39-* cp310-* cp311-*
+        CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
         CIBW_SKIP: '*-musllinux_*'    #  numpy doesn't have wheels for musllinux so we can't build some quickly and without bloating
         CIBW_ARCHS_LINUX: x86_64
         CIBW_ARCHS_MACOS: x86_64 arm64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,10 @@ requires = [
 
     # see https://github.com/yt-project/ewah_bool_utils/issues/52
     "Cython>=3.0, <3.1",
-    "oldest-supported-numpy",
+
+    # TODO: simplify numpy requirement after numpy 1.26.0 final is released
+    "oldest-supported-numpy ; python_version < '3.12.0rc1'",
+    "numpy>=1.26.0b1 ; python_version >= '3.12.0rc1'",
 ]
 
 [project]


### PR DESCRIPTION
requires #51 + numpy wheels (probably won't happen before numpy 1.26)