### PR TITLE
BLD: discontinue wheels for Windows 32

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -34,7 +34,7 @@ jobs:
         CIBW_ARCHS_LINUX: x86_64
         CIBW_ARCHS_MACOS: x86_64 arm64
         MACOSX_DEPLOYMENT_TARGET: '10.9'   # as of CIBW 2.9, this is the default value, pin it so it can't be bumped silently
-        CIBW_ARCHS_WINDOWS: auto
+        CIBW_ARCHS_WINDOWS: auto64
         CIBW_ENVIRONMENT: LDFLAGS='-static-libstdc++'
         CIBW_BUILD_VERBOSITY: 1
 


### PR DESCRIPTION
Numpy has stopped supporting this arch, which makes building ewah-bool-utils against most recent Python targets (3.12) impossible, so let's drop this arch too.
Note that it was also dropped in yt-dev a couple month back: https://github.com/yt-project/yt/pull/4523