### PR TITLE
DEP: unpin numpy runtime dependency to keep future-proofing tests useful

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   # https://github.com/scipy/oldest-supported-numpy/issues/76#issuecomment-1628865694
 
   # after Python 3.8 is dropped, keep in sync with NPY_TARGET_VERSION (setup.py)
-  "numpy>=1.17.3,<2.0",
+  "numpy>=1.17.3",
 ]
 classifiers = [
     "Intended Audience :: Developers",


### PR DESCRIPTION
Just noticed that this upper limit prevented testing yt againt numpy 2.0, removing it for a second release candidate.