### PR TITLE
DEP: drop support for CPython 3.8

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -22,7 +22,6 @@ jobs:
         os:
         - ubuntu-latest
         python-version:
-        - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'
@@ -30,9 +29,9 @@ jobs:
         # Test all on ubuntu, test ends on macos and windows
         include:
         - os: macos-latest
-          python-version: '3.8'
+          python-version: '3.9'
         - os: windows-latest
-          python-version: '3.8'
+          python-version: '3.9'
         - os: macos-latest
           python-version: '3.11'
         - os: windows-latest

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -29,8 +29,7 @@ jobs:
       with:
         output-dir: dist
       env:
-        CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
-        CIBW_SKIP: '*cp38-musllinux_*'  #  numpy doesn't have wheels for musllinux + py38
+        CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
         CIBW_ARCHS_LINUX: x86_64
         CIBW_ARCHS_MACOS: x86_64 arm64
         MACOSX_DEPLOYMENT_TARGET: '10.9'   # as of CIBW 2.9, this is the default value, pin it so it can't be bumped silently

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,8 @@ requires = [
     "Cython>=3.0, <3.1",
 
     # TODO: simplify numpy requirement after numpy 1.26.0 final is released
-    "oldest-supported-numpy ; python_version < '3.9'",
-    "numpy>=1.25, <2.0 ; python_version >= '3.9' and python_version < '3.12.0rc1'",
-    "numpy>=1.26.0b1, <2.0; python_version >= '3.12.0rc1'",
+    "numpy>=1.25, <2.0 ; python_version < '3.12'",
+    "numpy>=1.26.0b1, <2.0; python_version >= '3.12'",
 ]
 
 [project]
@@ -20,14 +19,12 @@ authors = [
   { name = "Meagan Lang" },
   { name = "Navaneeth Suresh" },
 ]
-requires-python =">=3.8"
+requires-python =">=3.9"
 dependencies = [
   # match the absolute oldest version of numpy with *any*
   # level of support for our minimal Python requirement
   # https://github.com/scipy/oldest-supported-numpy/issues/76#issuecomment-1628865694
-
-  # after Python 3.8 is dropped, keep in sync with NPY_TARGET_VERSION (setup.py)
-  "numpy>=1.17.3",
+  "numpy>=1.19.3",
 ]
 classifiers = [
     "Intended Audience :: Developers",
@@ -35,8 +32,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Cython",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -61,7 +56,6 @@ license-files = [
 
 [tool.black]
 line-length = 88
-target-version = ['py38']
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -79,7 +73,6 @@ exclude = '''
 '''
 
 [tool.ruff]
-target-version = "py38" # https://github.com/charliermarsh/ruff/issues/2039
 exclude = ["*__init__.py"]
 ignore = ["E501"]
 select = [

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 import numpy as np
 from Cython.Build import cythonize
@@ -19,12 +18,9 @@ else:
 
 define_macros = [
     ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
-]
-if sys.version_info >= (3, 9):
     # keep in sync with runtime requirements (pyproject.toml)
-    define_macros.append(("NPY_TARGET_VERSION", "NPY_1_18_API_VERSION"))
-else:
-    pass
+    ("NPY_TARGET_VERSION", "NPY_1_19_API_VERSION"),
+]
 
 extensions = [
     Extension(

--- a/setupext.py
+++ b/setupext.py
@@ -50,11 +50,6 @@ def check_for_openmp():
     Code adapted from astropy_helpers, originally written by Tom
     Robitaille and Curtis McCully.
     """
-
-    # See https://bugs.python.org/issue25150
-    if sys.version_info[:3] == (3, 5, 0):
-        return False
-
     # Create a temporary directory
     ccompiler = new_compiler()
     customize_compiler(ccompiler)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,2 @@
 pytest>=6.2.4
-numpy>=1.26.0b1 ; python_version >= '3.12rc1'
+numpy>=1.26.0b1 ; python_version >= '3.12'


### PR DESCRIPTION
Removing uneeded complexity now that 3.8 isn't supported by yt any more.