### PR TITLE
TST: move tests to Python 3.12 (stable)

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -25,7 +25,7 @@ jobs:
         - '3.9'
         - '3.10'
         - '3.11'
-        - 3.12-dev
+        - '3.12'
         # Test all on ubuntu, test ends on macos and windows
         include:
         - os: macos-latest
@@ -33,9 +33,9 @@ jobs:
         - os: windows-latest
           python-version: '3.9'
         - os: macos-latest
-          python-version: '3.11'
+          python-version: '3.12'
         - os: windows-latest
-          python-version: '3.11'
+          python-version: '3.12'
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -67,7 +67,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: 3.x
     - name: install check-manifest
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
anticipating on the incoming release (I'm issuing a bunch of similar PRs on many projects now so I can just push buttons on the day it actually works)