### PR TITLE
BLD: don't statically link to libstdc++

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -38,7 +38,6 @@ jobs:
         CIBW_ARCHS_LINUX: x86_64
         MACOSX_DEPLOYMENT_TARGET: '10.9'   # as of CIBW 2.9, this is the default value, pin it so it can't be bumped silently
         CIBW_ARCHS_WINDOWS: auto64
-        CIBW_ENVIRONMENT: LDFLAGS='-static-libstdc++'
         CIBW_BUILD_VERBOSITY: 1
         CIBW_TEST_COMMAND: >
           python -m pip install -r {project}/test_requirements.txt


### PR DESCRIPTION
Linking to libstdc++ statically causes weird memory errors when trying to import other extensions that link to it dynamically (e.g. matplotlib, contourpy). https://github.com/yt-project/yt/issues/4910 is the same issue in yt.

This script should reproduce the crash:
```sh
#!/bin/sh
export CIBW_BUILD='cp39-*'
export CIBW_SKIP='*-musllinux_*'
export CIBW_ARCHS_LINUX='x86_64'
export CIBW_ENVIRONMENT="LDFLAGS='-static-libstdc++'"
export CIBW_BUILD_VERBOSITY=1
export CIBW_TEST_COMMAND=' \
python -m pip install -r {project}/test_requirements.txt contourpy \
&& python -c "import ewah_bool_utils.ewah_bool_wrap; import contourpy"'
cibuildwheel --output-dir dist
```

Running python under gdb gives the following backtrace:
<details><summary>Details</summary>
<p>

```
*** Error in `/tmp/tmp.SvMHbvY4MK/venv/bin/python': free(): invalid pointer: 0x00007f415618fc80 ***
...
Program received signal SIGABRT, Aborted.
0x00007f41964f7387 in raise () from /lib64/libc.so.6
#0  0x00007f41964f7387 in raise () from /lib64/libc.so.6
#1  0x00007f41964f8a78 in abort () from /lib64/libc.so.6
#2  0x00007f4196539f67 in __libc_message () from /lib64/libc.so.6
#3  0x00007f4196542329 in _int_free () from /lib64/libc.so.6
#4  0x00007f4155ef9192 in std::locale::_Impl::_M_install_facet(std::locale::id const*, std::locale::facet const*) () from /lib64/libstdc++.so.6
#5  0x00007f4155ef95e3 in std::locale::_Impl::_Impl(unsigned long) ()
   from /lib64/libstdc++.so.6
#6  0x00007f4155efa555 in ?? () from /lib64/libstdc++.so.6
#7  0x00007f4196f9e20b in __pthread_once_slow () from /lib64/libpthread.so.0
#8  0x00007f4155efa5a1 in ?? () from /lib64/libstdc++.so.6
#9  0x00007f4155efa5e3 in std::locale::locale() () from /lib64/libstdc++.so.6
#10 0x00007f4155ef743c in std::ios_base::Init::Init() ()
   from /lib64/libstdc++.so.6
#11 0x00007f418527f050 in _GLOBAL__sub_I_chunk_local.cpp ()
   from /tmp/tmp.SvMHbvY4MK/venv/lib/python3.9/site-packages/contourpy/_contourpy.cpython-39-x86_64-linux-gnu.so
#12 0x00007f41971c39c3 in _dl_init_internal ()
   from /lib64/ld-linux-x86-64.so.2
#13 0x00007f41971c859e in dl_open_worker () from /lib64/ld-linux-x86-64.so.2
#14 0x00007f41971c37d4 in _dl_catch_error () from /lib64/ld-linux-x86-64.so.2
#15 0x00007f41971c7b8b in _dl_open () from /lib64/ld-linux-x86-64.so.2
#16 0x00007f4196d94fab in dlopen_doit () from /lib64/libdl.so.2
#17 0x00007f41971c37d4 in _dl_catch_error () from /lib64/ld-linux-x86-64.so.2
#18 0x00007f4196d955ad in _dlerror_run () from /lib64/libdl.so.2
#19 0x00007f4196d95041 in dlopen@@GLIBC_2.2.5 () from /lib64/libdl.so.2
#20 0x0000000000506f01 in ?? ()
...
```

</p>
</details> 

As I understand it, the `std::locale` static initialization code runs a second time when `libstdc++.so.6` is loaded by `_contourpy`, which breaks some assumptions about the global state. Here's some discussion on the gcc-help mailing list about what is probably the same issue: https://gcc.gnu.org/legacy-ml/gcc-help/2017-05/msg00164.html.