### PR TITLE
BLD: add support for building against free-threaded CPython builds

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -15,12 +15,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: tests with bleeding-edge crucial deps
+    name: tests with bleeding-edge crucial deps (${{ matrix.python-version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+        - '3.14'
+        - 3.14t
     timeout-minutes: 60
 
     concurrency:
       # auto-cancel any in-progress job *on the same branch*
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.python-version }}
       cancel-in-progress: true
 
     steps:
@@ -30,18 +36,22 @@ jobs:
       with:
         # numpy cp314 nightlies require at least 3.14.0b1, which is not available
         # via uv at the time of writing.
-        python-version: '3.14'
+        python-version: ${{ matrix.python-version }}
         allow-prereleases: true
     - uses: astral-sh/setup-uv@v6
       with:
         activate-environment: true
     - name: Configure uv
       run: |
+        pin=${{ matrix.python-version }}
+        echo "UV_PYTHON=${pin%-dev}" >> $GITHUB_ENV
+        echo "UV_PYTHON_PREFERENCE=only-system" >> $GITHUB_ENV
         echo "UV_PRERELEASE=allow" >> $GITHUB_ENV
         echo "UV_INDEX=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" >> $GITHUB_ENV
         echo "UV_INDEX_STRATEGY=unsafe-best-match" >> $GITHUB_ENV
     - name: Install dependencies
       run: |
+        uv venv
         uv pip install --no-build setuptools wheel numpy Cython
 
     - name: Build
@@ -52,6 +62,10 @@ jobs:
         uv pip install -e . --no-build-isolation --group test
 
     - run: uv pip list
+
+    - if: ${{ endsWith( matrix.python-version , 't') }}
+      run: |
+        echo "PYTHON_GIL=0" >> $GITHUB_ENV
 
     - name: Run Tests
       run: pytest --color=yes -ra

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+import sys
+from importlib.metadata import version
+
+
+def pytest_report_header(config, start_path):
+    is_gil_enabled = sys.version_info < (3, 13) or sys._is_gil_enabled()
+
+    return [
+        f"{is_gil_enabled = }",
+        f"NumPy: {version('numpy')}",
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: Free Threading :: 1 - Unstable"
 ]
 
 [project.license]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ license-files = [
 
 [dependency-groups]
 test = [
-    "pytest>=6.2.4",
+    "pytest>=7.0.0",
 ]
 
 [tool.ruff.lint]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import sysconfig
 from distutils.ccompiler import get_default_compiler
 from enum import IntEnum
 
@@ -59,7 +60,9 @@ def pyver_hex() -> str:
         return hex_
 
 
-USE_PY_LIMITED_API = sys.version_info >= (3, 11)
+USE_PY_LIMITED_API = sys.version_info >= (3, 11) and not sysconfig.get_config_var(
+    "Py_GIL_DISABLED"
+)
 ABI3_TARGET_VERSION = "".join(str(_) for _ in sys.version_info[:2])
 ABI3_TARGET_HEX = pyver_hex()
 


### PR DESCRIPTION
Release notes should mention something along these lines:

This version deliberately allows building against free-threading CPython, but note that
- thread safety isn't verified or guaranteed at this stage
- runtime testing may require explicitly setting `PYTHON_GIL=0`
- no pre-built wheels are provided at this time
In essence, we merely allow dowstream *experimentation* with free-threaded builds. Please report any thread-safety issue encountered with ewah-bool-utils' API discovered in such experiments.
