### PR TITLE
WHL: stop shipping wheels for macOS x86_64 (mac-intel)

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -22,8 +22,7 @@ jobs:
         os:
         - ubuntu-latest
         - windows-latest
-        - macos-13    # x86_64
-        - macos-14    # arm64
+        - macos-latest
 
       fail-fast: false
 


### PR DESCRIPTION
To be merged when the `macos-13` image is discontinued, sometimes between Sept 1st and Nov 15th
