### PR TITLE
CLN: cleanup unused cibuildwheel overrides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,3 @@ archs = "auto64"
 
 [tool.cibuildwheel.windows]
 archs = "auto64"
-
-[[tool.cibuildwheel.overrides]]
-# Install numpy from nightly wheels as not yet on PyPI.
-select = "cp314*"
-before-test = "uv pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"


### PR DESCRIPTION
This became immediately obsolete with the release of numpy 2.3.2