### PR TITLE
DEP: drop support for CPython 3.10

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -23,23 +23,22 @@ jobs:
         os:
         - ubuntu-latest
         python-version:
-        - 3.10.0
-        - '3.11'
+        - 3.11.0
         - '3.12'
         - '3.13'
         - '3.14'
         # Test all on ubuntu, test ends on macos and windows
         include:
         - os: macos-latest
-          python-version: 3.10.0
+          python-version: 3.11.0
         - os: windows-latest
-          python-version: 3.10.0
+          python-version: 3.11.0
         - os: macos-latest
           python-version: '3.14'
         - os: windows-latest
           python-version: '3.14'
         - os: ubuntu-22.04
-          python-version: 3.10.0
+          python-version: 3.11.0
           install-args: --resolution=lowest
 
     runs-on: ${{ matrix.os }}
@@ -49,9 +48,12 @@ jobs:
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         persist-credentials: false
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        # 3.11.0 is not available through setup-uv
+        python-version: ${{ matrix.python-version }}
     - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
       with:
-        python-version: ${{ matrix.python-version }}
         prune-cache: false
 
     - name: Build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,11 @@ authors = [
   { name = "Meagan Lang" },
   { name = "Navaneeth Suresh" },
 ]
-requires-python =">=3.10"
+requires-python =">=3.11"
 dependencies = [
   # match the absolute oldest version of numpy with *any*
   # level of support for our minimal Python requirement
-  "numpy>=1.21.2, <3",
+  "numpy>=1.23.2, <3",
 ]
 license = "Apache-2.0 AND BSD-2-Clause"
 license-files = [
@@ -32,7 +32,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Cython",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/setup.py
+++ b/setup.py
@@ -24,13 +24,10 @@ else:
 
 # restrict LIMITED_API usage:
 # - require an env var EWAH_BOOL_UTILS_LIMITED_API=1
-# - compiling with Python 3.10 doesn't work (as of Cython 3.1.1)
 # - LIMITED_API is not compatible with free-threading (as of CPython 3.14)
-USE_PY_LIMITED_API = (
-    os.environ.get("EWAH_BOOL_UTILS_LIMITED_API") == "1"
-    and sys.version_info >= (3, 11)
-    and not sysconfig.get_config_var("Py_GIL_DISABLED")
-)
+USE_PY_LIMITED_API = os.environ.get(
+    "EWAH_BOOL_UTILS_LIMITED_API"
+) == "1" and not sysconfig.get_config_var("Py_GIL_DISABLED")
 ABI3_TARGET_VERSION = "".join(str(_) for _ in sys.version_info[:2])
 ABI3_TARGET_HEX = hex(sys.hexversion & 0xFFFF00F0)
 
@@ -38,7 +35,7 @@ ABI3_TARGET_HEX = hex(sys.hexversion & 0xFFFF00F0)
 define_macros = [
     ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
     # keep in sync with runtime requirements (pyproject.toml)
-    ("NPY_TARGET_VERSION", "NPY_1_19_API_VERSION"),
+    ("NPY_TARGET_VERSION", "NPY_1_23_API_VERSION"),
 ]
 if USE_PY_LIMITED_API:
     define_macros.append(("Py_LIMITED_API", ABI3_TARGET_HEX))


### PR DESCRIPTION
motivation: remove a bit of complexity before I attempt migrating to meson-python